### PR TITLE
FIX Karma singleRun=False, except when in Travis, to enable debugging ...

### DIFF
--- a/angular-client/karma.conf.js
+++ b/angular-client/karma.conf.js
@@ -35,9 +35,10 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: true
+    singleRun: false,
   });
   if(process.env.TRAVIS){
     config.browsers = ['Chrome_travis_ci'];
+    config.singleRun = true;
   }
 };


### PR DESCRIPTION
By request of Her Awesomeness, Liuai the Merciful, she needs debugging back, which I had turned off for Travis... Now we can have both, a singleRun = true for Travis, and singleRun= false to enable debugging by our beloved kickass devs.